### PR TITLE
#162024906 Add Admin can change parcel status endpoint

### DIFF
--- a/spec/routes/parcels.spec.js
+++ b/spec/routes/parcels.spec.js
@@ -167,4 +167,33 @@ describe('parcel', () => {
       expect(data.message).toBe('Parcel location changed successfully');
     });
   });
+
+  // Change parcel location
+  describe('change a parcel status PUT /api/v1/parcels/<parcelId>/status', () => {
+    const data = {};
+    beforeAll((done) => {
+      Request.put(`${urlPrefixV1}/parcels/${parcelId}/status`,
+        {
+          json: true,
+          form: { parcelStatus: 'Gisenyi' },
+          headers: {
+            Authorization: `Bearer ${userToken}`,
+          },
+        }, (err, res, body) => {
+          data.status = res.statusCode;
+          if (!err) {
+            data.success = body.success;
+            data.message = body.msg;
+          }
+          done();
+        });
+    });
+    it('Status 200', () => {
+      expect(data.status).toBe(200);
+    });
+    it('Body', () => {
+      expect(data.success).toBe(true);
+      expect(data.message).toBe('Parcel status changed successfully');
+    });
+  });
 });

--- a/src/routes/parcels.js
+++ b/src/routes/parcels.js
@@ -96,4 +96,23 @@ router.put('/:id/location',
     return res.status(200).json({ success: true, msg: 'Parcel location changed successfully' });
   });
 
+// Change parcel location
+router.put('/:id/location',
+  celebrate({ body: parcels.changeStatus }),
+  jwtVerifyToken(['admin']),
+  (req, res) => {
+    const { id } = req.params;
+    const { parcelStatus } = req.body;
+    let parcel = new Parcel();
+    parcel = parcel.findById(id);
+    if (!parcel) {
+      return res.status(404).json({ success: false, msg: 'Not found' });
+    }
+
+    parcel.parcelStatus = parcelStatus;
+    parcel.save();
+
+    return res.status(200).json({ success: true, msg: 'Parcel status changed successfully' });
+  });
+
 export default router;

--- a/src/validators/parcels.js
+++ b/src/validators/parcels.js
@@ -21,9 +21,20 @@ const changeLocation = {
   location: Joi.string().required(),
 };
 
+const changeStatus = {
+  parcelStatus: Joi.string().valid(
+    'Waiting Pickup',
+    'Pick Up',
+    'In Transit',
+    'Pending',
+    'Delivered',
+  ).required(),
+};
+
 
 export default {
   create,
   cancel,
   changeLocation,
+  changeStatus,
 };


### PR DESCRIPTION
#### What does this PR do?
Adds admin can change parcel status endpoint

#### Description of Task to be completed?
- Add unit test
- Add Joi validator for the request body
- Restrict the endpoint to Admins only
- Add change parcel status endpoint as ```PUT /api/v1/parcels/parcelId/status```

#### How should this be manually tested?
Use Postman to make a PUT request to ```PUT /api/v1/parcels/parcelId/status``` with an admin access token