### PR TITLE
#162064709 Add receiver's names in the admin order page

### DIFF
--- a/order.html
+++ b/order.html
@@ -139,6 +139,14 @@
               </div>
 
               <div class="row">
+                <div class="col-6">
+                  <label for="receiverNames" class="title">Receiver Names</label>
+                  <input type="text" name="receiverNames" id="receiverNames">
+                  <div class="form-error receiverNames"></div>
+                </div>
+              </div>
+              
+              <div class="row">
                 <div class="col-12">
                   <label for="address" class="title">Address</label>
                   <textarea


### PR DESCRIPTION
#### What does this PR do?
Adds a new form field for the receiver's names in the admin order page

#### Description of Task to be completed?
- Adding a receiver's names in the admin order page

#### How should this be manually tested?
Here are the steps to follow in order to navigate to the admin order detail page of the UI
* Open the git hub page link [gh-pages](https://oesukam.github.io/andela-sendit/)
* From the main menu on top the page, put the cursor on the Admin link menu to see the dropdown menu
* Click on Admin update an order
* Scroll the page down to see Receiver's Names field that was added

#### Screenshots
![receiver s names](https://user-images.githubusercontent.com/17350127/48769340-14b5bd00-ecc4-11e8-9926-c1c8877854df.png)

